### PR TITLE
Add task categories

### DIFF
--- a/laravel-app/app/Http/Controllers/TaskController.php
+++ b/laravel-app/app/Http/Controllers/TaskController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Task;
+use App\Models\Category;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
@@ -35,7 +36,8 @@ class TaskController extends Controller
 
     public function create()
     {
-        return view('tasks.create');
+        $categories = Category::all();
+        return view('tasks.create', compact('categories'));
     }
 
     public function store(Request $request)
@@ -43,6 +45,7 @@ class TaskController extends Controller
         $validated = $request->validate([
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
+            'category_id' => 'nullable|exists:categories,id',
         ]);
 
         Task::create([
@@ -50,6 +53,7 @@ class TaskController extends Controller
             'description' => $validated['description'],
             'is_completed' => false,
             'user_id' => Auth::id(),
+            'category_id' => $validated['category_id'] ?? null,
         ]);
 
         return redirect()->route('tasks.index');
@@ -65,7 +69,8 @@ class TaskController extends Controller
     {
         $task = Task::where('id', $id)->where('user_id', Auth::id())->firstOrFail();
         $this->authorize('update', $task);
-        return view('tasks.edit', compact('task'));
+        $categories = Category::all();
+        return view('tasks.edit', compact('task', 'categories'));
     }
 
     public function update(Request $request, Task $task)
@@ -75,6 +80,7 @@ class TaskController extends Controller
             'title' => 'required|string|max:255',
             'description' => 'nullable|string',
             'due_date' => 'nullable|date',
+            'category_id' => 'nullable|exists:categories,id',
         ]);
 
         $task->update($validated);

--- a/laravel-app/app/Models/Category.php
+++ b/laravel-app/app/Models/Category.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Category extends Model
+{
+    protected $fillable = ['name'];
+
+    public function tasks(): HasMany
+    {
+        return $this->hasMany(Task::class);
+    }
+}

--- a/laravel-app/app/Models/Task.php
+++ b/laravel-app/app/Models/Task.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\Category;
 
 class Task extends Model
 {
@@ -11,10 +13,16 @@ class Task extends Model
         'description',
         'is_completed',
         'user_id',
+        'category_id',
         'due_date', // ← bunu ekle
     ];
 
     protected $casts = [
         'due_date' => 'date',
     ];
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
 }

--- a/laravel-app/database/migrations/2025_07_21_130000_create_categories_table.php
+++ b/laravel-app/database/migrations/2025_07_21_130000_create_categories_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/laravel-app/database/migrations/2025_07_21_131000_add_category_id_to_tasks_table.php
+++ b/laravel-app/database/migrations/2025_07_21_131000_add_category_id_to_tasks_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->unsignedBigInteger('category_id')->nullable()->after('user_id');
+            $table->foreign('category_id')->references('id')->on('categories')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropForeign(['category_id']);
+            $table->dropColumn('category_id');
+        });
+    }
+};

--- a/laravel-app/database/seeders/DatabaseSeeder.php
+++ b/laravel-app/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use App\Models\Category;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -19,5 +20,9 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        foreach (['Genel', 'İş', 'Kişisel'] as $name) {
+            Category::create(['name' => $name]);
+        }
     }
 }

--- a/laravel-app/resources/views/tasks/create.blade.php
+++ b/laravel-app/resources/views/tasks/create.blade.php
@@ -27,6 +27,16 @@
                             class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-500 focus:ring-opacity-50"></textarea>
                     </div>
 
+                    <div class="mb-5">
+                        <label for="category_id" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Kategori</label>
+                        <select id="category_id" name="category_id" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-500 focus:ring-opacity-50">
+                            <option value="">Seçiniz</option>
+                            @foreach ($categories as $category)
+                                <option value="{{ $category->id }}">{{ $category->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+
                     <div class="flex justify-between items-center mt-6">
                         <a href="{{ route('tasks.index') }}"
                             class="text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:underline">← Geri Dön</a>

--- a/laravel-app/resources/views/tasks/edit.blade.php
+++ b/laravel-app/resources/views/tasks/edit.blade.php
@@ -40,6 +40,19 @@
                             @enderror
                         </div>
 
+                        <div class="mb-4">
+                            <label for="category_id" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Kategori</label>
+                            <select name="category_id" id="category_id" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-800 dark:text-white">
+                                <option value="">Seçiniz</option>
+                                @foreach ($categories as $category)
+                                    <option value="{{ $category->id }}" @selected(old('category_id', $task->category_id) == $category->id)>{{ $category->name }}</option>
+                                @endforeach
+                            </select>
+                            @error('category_id')
+                                <p class="text-red-500 text-sm mt-1">{{ $message }}</p>
+                            @enderror
+                        </div>
+
                         <div class="flex justify-end">
                             <a href="{{ route('tasks.index') }}" class="inline-flex items-center px-4 py-2 bg-gray-500 dark:bg-gray-600 text-white text-sm font-medium rounded-md hover:bg-gray-700 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 mr-2">
                                 İptal

--- a/laravel-app/resources/views/tasks/index.blade.php
+++ b/laravel-app/resources/views/tasks/index.blade.php
@@ -39,6 +39,9 @@
                             {{ $task->title }}
                         </a>
                     </h3>
+                    @if($task->category)
+                        <p class="text-xs text-gray-400 mt-1">{{ $task->category->name }}</p>
+                    @endif
                     <p class="text-sm text-gray-600 dark:text-gray-300 mt-1">{{ $task->description }}</p>
                     <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">Tarih: {{ $task->created_at->format('d.m.Y H:i') }}</p>
 

--- a/laravel-app/resources/views/tasks/show.blade.php
+++ b/laravel-app/resources/views/tasks/show.blade.php
@@ -27,6 +27,13 @@
                             <p class="mt-1 text-gray-800 dark:text-gray-200">{{ $task->description ?? 'Açıklama yok.' }}</p>
                         </div>
 
+                        @if($task->category)
+                        <div>
+                            <span class="text-md font-medium text-gray-700 dark:text-gray-300">Kategori:</span>
+                            <p class="mt-1 text-gray-800 dark:text-gray-200">{{ $task->category->name }}</p>
+                        </div>
+                        @endif
+
                         <div>
                             <span class="text-md font-medium text-gray-700 dark:text-gray-300">Son Tarih:</span>
                             <p class="mt-1 text-gray-800 dark:text-gray-200">


### PR DESCRIPTION
## Summary
- add `Category` model with migrations
- relate tasks to categories
- show category pickers in create/edit forms
- display category info on task list and detail views
- seed some default categories

## Testing
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e403e9f2c8325b4dcdc2943ca090a